### PR TITLE
Fix give consent error with data Array

### DIFF
--- a/src/controllers/consentsController.ts
+++ b/src/controllers/consentsController.ts
@@ -399,6 +399,14 @@ export const giveConsent = async (
     }
 
     if (userId) {
+      if (data) {
+        data = privacyNotice.data.filter((dt: any) => {
+          if (data.includes(dt.resource)) {
+            return dt;
+          }
+        });
+      }
+
       const verification = await Consent.findOne({
         providerUserIdentifier: providerUserIdentifier._id,
         consumerUserIdentifier: consumerUserIdentifier._id,
@@ -410,14 +418,6 @@ export const giveConsent = async (
 
       if (verification) {
         return res.status(200).json(verification);
-      }
-
-      if (data) {
-        data = privacyNotice.data.filter((dt: any) => {
-          if (data.includes(dt.resource)) {
-            return dt;
-          }
-        });
       }
 
       const consent = new Consent({


### PR DESCRIPTION
### fix 

- fix error in give consent routes, the verification need an object for data field but get a string. The filter of the data body params has been moved before the verification