### PR TITLE
Query params & postbuild scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "generateAES": "openssl rand -out src/config/keys/AESKey.pem -hex 16",
     "generatePublicKey": "openssl rsa -in src/config/keys/consentSignature.pem -outform PEM -pubout -out src/config/keys/consentSignaturePublic.pem",
     "copyKeys": "copyfiles --up 1 src/config/keys/* ./dist/src",
-    "postbuild": "npm run copyKeys",
+    "postbuild": "pnpm copyKeys",
     "open:report": "open mochawesome-report/mochawesome.html"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "generateAES": "openssl rand -out src/config/keys/AESKey.pem -hex 16",
     "generatePublicKey": "openssl rsa -in src/config/keys/consentSignature.pem -outform PEM -pubout -out src/config/keys/consentSignaturePublic.pem",
     "copyKeys": "copyfiles --up 1 src/config/keys/* ./dist/src",
+    "postbuild": "npm run copyKeys",
     "open:report": "open mochawesome-report/mochawesome.html"
   },
   "keywords": [

--- a/src/controllers/consentsController.ts
+++ b/src/controllers/consentsController.ts
@@ -51,7 +51,7 @@ export const getUserConsents = async (
   next: NextFunction
 ) => {
   try {
-    const { limit = "10", page = "1" } = req.query;
+    const { limit = "10", page = "1", receipt = false } = req.query;
 
     const skip = (parseInt(page.toString()) - 1) * parseInt(limit.toString());
 
@@ -81,7 +81,11 @@ export const getUserConsents = async (
       consentReceipts.push(await consentToConsentReceipt(consent));
     }
 
-    res.json({ consents: consentReceipts, totalCount, totalPages });
+    res.json({
+      consents: receipt ? consents : consentReceipts,
+      totalCount,
+      totalPages,
+    });
   } catch (err) {
     next(err);
   }


### PR DESCRIPTION
* Adds optional query params to consent fetches to retrieve additionnal information on consent records / receipts
* Adds a postbuild action to ensure generated keys are always moved from src to the new build